### PR TITLE
Added 5 fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,11 +116,16 @@ Cover:: {{VALUE:thumbnail}}
 ISBN10:: {{VALUE:isbn10}}
 ISBN13:: {{VALUE:isbn13}}
 URL:: [Goodreads]({{VALUE:goodreadsURL}})
+Genre:: {{VALUE:genre}}
+PageCount:: {{VALUE:pageCount}}
+AverageRating:: {{VALUE:avRating}}
 Rating:: {{VALUE:rating}}
+Maturity:: {{VALUE:mature}}
 Read:: {{VALUE:read}}
 Recommender:: {{VALUE:recommender}}
 Date:: {{DATE}}
 Comment:: {{VALUE:comment}}
+BookDescription:: {{VALUE: bookDesc}}
 
 ```
 
@@ -136,11 +141,11 @@ Author,
 publish-date AS "Publish date",
 ("![coverImg|100](" + Cover + ")") as Cover,
 rating AS "Rating",
-genre AS "Genre",
-avRating AS "Average Rating",
-mature AS "Maturity Rating",
-pageCount AS "Page Count",
-bookDesc AS "Book Description",
+AverageRating AS "Average Rating",
+Maturity AS "Maturity Rating",
+PageCount AS "Page Count",
+BookDescription AS "Book Description",
+Genre,
 Recommender,
 Comment,
 Date,

--- a/README.md
+++ b/README.md
@@ -136,6 +136,11 @@ Author,
 publish-date AS "Publish date",
 ("![coverImg|100](" + Cover + ")") as Cover,
 rating AS "Rating",
+genre AS "Genre",
+avRating AS "Average Rating",
+mature AS "Maturity Rating",
+pageCount AS "Page Count",
+bookDesc AS "Book Description",
 Recommender,
 Comment,
 Date,
@@ -171,6 +176,16 @@ Please find here a definition of the possible variables to be used in your templ
 `goodreadsURL` : An URL that uses the ISBN to request Goodreads book page. This may fail if ISBN returned by Google is not in the database of Goodreads.
 
 `rating` : Your book rating, /10.
+
+`avRating` : Average rating from all ratings in API.
+
+`genre` : The reported genre of the book.
+
+`pageCount` : Total number of pages in this book.
+
+`mature` : Is this book rated mature or not?
+
+`bookDesc` : What is the blurb of the book?
 
 `read` : If you read the book, this equals 1, otherwise 0 (this helps to filter dataview query).
 

--- a/script_googleBooks_quickAdd.js
+++ b/script_googleBooks_quickAdd.js
@@ -107,8 +107,8 @@ async function start(params, settings) {
 		genre: `${selectedBook.categories ? selectedBook.categories : "N/A"}`,
 		// A rating for the read book, /10.
 		rating: myRating,
-		// The global average review /5
-		avRating: `${selectedBook.averageRating ? selectedBook.averageRating : 0 }`,
+		// The global average review * 2 to get /10
+		avRating: `${selectedBook.averageRating ? selectedBook.averageRating * 2 : 0 }`,
 		// For mature audiences or not?
 		mature: `${selectedBook.maturityRating ? selectedBook.maturityRating : "NA" }`,
 		// Pages reported in book

--- a/script_googleBooks_quickAdd.js
+++ b/script_googleBooks_quickAdd.js
@@ -9,18 +9,18 @@ const API_KEY = "Google Books API Key"
 const GOODREADS_URL = "https://www.goodreads.com/search?qid=&q="
 
 module.exports = {
-  entry: start,
-  settings: {
-    name: "Books script",
-    author: "Elaws",
-    options: {
-      [API_KEY]: {
-        type: "text",
-        defaultValue: "",
-        placeholder: "Google Books API Key",
-      }
-    },
-  },
+	entry: start,
+	settings: {
+		name: "Books script",
+		author: "Elaws",
+		options: {
+			[API_KEY]: {
+				type: "text",
+				defaultValue: "",
+				placeholder: "Google Books API Key",
+			}
+		},
+	},
 };
 
 let QuickAdd;
@@ -94,6 +94,7 @@ async function start(params, settings) {
 		authors: formatList(selectedBook.authors),
 		isbn10: `${ISBN.ISBN10 ? ISBN.ISBN10 : " "}`,
 		isbn13: `${ISBN.ISBN13 ? ISBN.ISBN13 : " "}`,
+
 		// An URL to the GoodReads page of the book using its ISBN. 
 		// May fail if ISBN returned by Google Books is not in Goodreads database.
 		goodreadsURL: `${ISBN.ISBN13 ? GOODREADS_URL + ISBN.ISBN13 : (ISBN.ISBN10 ? GOODREADS_URL + ISBN.ISBN10 : " ")}`,
@@ -102,8 +103,18 @@ async function start(params, settings) {
 		release: `${selectedBook.publishedDate ? (new Date((selectedBook.publishedDate))).getFullYear() : " "}`,
 		// Squares of different color to tag Obsidian's note, depending if book has already been read or not.
 		tag: `${isRead ? "\u{0001F7E7}" : "\u{0001F7E5}"}`,
+		// Main Category reported for the book
+		genre: `${selectedBook.categories ? selectedBook.categories : "N/A"}`,
 		// A rating for the read book, /10.
 		rating: myRating,
+		// The global average review /5
+		avRating: `${selectedBook.averageRating ? selectedBook.averageRating : 0 }`,
+		// For mature audiences or not?
+		mature: `${selectedBook.maturityRating ? selectedBook.maturityRating : "NA" }`,
+		// Pages reported in book
+		pageCount: `${selectedBook.pageCount ? selectedBook.pageCount : 0 }`,
+		// blurb
+		bookDesc: `${selectedBook.description ? selectedBook.description : "No Description Reported" }`,
 		// Is the book already read ? 1 if yes, 0 otherwise.
 		read: `${isRead ? "1" : "0"}`,
 		// Who recommended the book to me?
@@ -157,13 +168,13 @@ async function getByQuery(query) {
 
 	if(searchResults.error)
     {
-      notice("Request failed");
-      throw new Error("Request failed");
+		notice("Request failed");
+		throw new Error("Request failed");
     }
 
     if (searchResults.totalItems == 0) {
-      notice("No results found.");
-      throw new Error("No results found.");
+		notice("No results found.");
+		throw new Error("No results found.");
     }
 
     return searchResults.items;
@@ -185,7 +196,7 @@ async function apiGet(query) {
 	let finalURL = new URL(API_URL);
 
 	finalURL.searchParams.append("q", query);
-  	finalURL.searchParams.append("key", Settings[API_KEY]);
+	finalURL.searchParams.append("key", Settings[API_KEY]);
 
 	log(finalURL.href);
 


### PR DESCRIPTION
Hi Elaws,

Thanks for producing such a robust script, I've been using it quite a bit over the weekend.

I've added another 5 fields from the API that I quite like to have:
- avRating - Average Rating reported by the API
- genre - the categories field in the API
- bookDesc - The blurb of the book
- mature - A rating for whether or not a book is rated as MATURE or NOT_MATURE
- pageCount - The total number of pages reported for the book

This all works <-- 

I also tried adding retail information, I like to sum up how much my books have cost me and how much I'll be spending on those I haven't read or bought yet, but I ran into an issue where it just does not exist in many cases.

I tried:

```
	const selectedBookRetail = selection.saleInfo.retailPrice;

	let gprice = 0
        // Presence of retailPrice.amount indicates presence of currencyCode
	if (typeof(selectedBookRetail.amount) !== "undefined") {
		let getPrice = selectedBookRetail.amount
                let getCurrency = selectedBookRetail.currencyCode
	}
       ......
        currency: getCurrency
        price: getPrice
```

But I don't know enough JavaScript to make this work completely. But I'll work on that if you don't want to.
Thanks,
DLBPointon